### PR TITLE
fix(ci): checkout before running Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Run Renovate
         uses: renovatebot/github-action@v46.1.1
         with:


### PR DESCRIPTION
Renovate GitHub Action was failing with ENOENT for renovate.json because the workflow didn't checkout the repo before running the action.

- Add actions/checkout@v4 before renovatebot/github-action
- Allows Renovate to read renovate.json from the workspace

Verification:
- Re-run Renovate workflow on this branch